### PR TITLE
Add : pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Perfect for red teamers, OSCP/CRTP/PNPT prep, quick post-collection triage, or w
 ## Installation
 
 ```bash
+# Install directly from GitHub (recommended)
+pipx install git+https://github.com/DotNetRussell/BloodBash
+```
+
+Or manually:
+
+```bash
 git clone https://github.com/dotnetrussell/bloodbash.git
 cd bloodbash
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "bloodbash"
+version = "1.3.1"
+description = "SharpHound & AzureHound offline analyzer: finds AD/Azure attack paths and misconfigurations"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.9"
+dependencies = [
+    "networkx>=3.0",
+    "rich>=13.0",
+    "tqdm>=4.0",
+    "pyyaml",
+]
+
+[project.scripts]
+bloodbash = "BloodBash:main"
+
+[tool.setuptools]
+py-modules = ["BloodBash"]


### PR DESCRIPTION
Makes BloodBash installable via pip, exposing a `bloodbash` CLI entry point.

- Adds pyproject.toml with setuptools build backend
- Declares dependencies (networkx, rich, tqdm, pyyaml)
- Registers `bloodbash = BloodBash:main` as a console script

Install:
    `pipx install git+https://github.com/DotNetRussell/BloodBash`
